### PR TITLE
Bring "return_dict" functionality to SHOW.

### DIFF
--- a/pydisque/client.py
+++ b/pydisque/client.py
@@ -365,14 +365,22 @@ class Client(object):
         """
         return self.execute_command("DELJOB", *job_ids)
 
-    def show(self, job_id):
+    # TODO (canardleteer): a JobStatus object may be the best for this,
+    #                      but I think SHOW is going to change to SHOWJOB
+    def show(self, job_id, return_dict=False):
         """
         Describe the job.
 
         :param job_id:
 
         """
-        return self.execute_command("SHOW", job_id)
+        rtn = self.execute_command('SHOW', job_id)
+
+        if return_dict:
+            grouped = self._grouper(rtn, 2)
+            rtn = dict( (a,b) for a,b in grouped)
+
+        return rtn
 
     def qscan(self, cursor=0, count=None, busyloop=None, minlen=None,
               maxlen=None, importrate=None):

--- a/tests/test_disque.py
+++ b/tests/test_disque.py
@@ -166,6 +166,7 @@ class TestDisque(unittest.TestCase):
         assert stat.get('jobs-in', None) is not None
         assert stat.get('jobs-out', None) is not None
 
+    # TODO (canardleteer): bring this back
     """
     def test_shownack(self):
         queuename = "test_show-%s" % self.testID

--- a/tests/test_disque.py
+++ b/tests/test_disque.py
@@ -166,9 +166,8 @@ class TestDisque(unittest.TestCase):
         assert stat.get('jobs-in', None) is not None
         assert stat.get('jobs-out', None) is not None
 
-    # TODO (canardleteer): bring this back
-    """
     def test_shownack(self):
+        """Test that NACK and SHOW work appropriately."""
         queuename = "test_show-%s" % self.testID
 
         test_job = six.b("Show me.")
@@ -179,12 +178,10 @@ class TestDisque(unittest.TestCase):
         for queue_name, job_id, job in jobs:
             self.client.nack_job(job_id)
 
-        shown = self.client.show(job_id)
+        shown = self.client.show(job_id, True)
 
-        print(shown)
+        assert shown.get('body') == test_job
+        assert shown.get('nacks') == 1
 
-        assert shown[six.b('body')] == test_job
-        assert shown[six.b('nacks')] == 1
-    """
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I have a whole lot going on currently, I think I updated show appropriately with return_dict, but I am out of time to rewrite my unit testing on the SHOW command in the same style I did for the QSTAT unit tests. If someone else can get to it before me, great. If not, I'll merge it ASAP with a test.  
