### PR TITLE
fix: retry=0

### DIFF
--- a/pydisque/client.py
+++ b/pydisque/client.py
@@ -182,7 +182,7 @@ class Client(object):
             before the job is queued by any server.
         :param retry: sec period after which, if no ACK is received, the
             job is put again into the queue for delivery. If RETRY is 0,
-            the job has an at-least-once delivery semantics.
+            the job has an at-most-once delivery semantics.
         :param ttl: sec is the max job life in seconds. After this time,
             the job is deleted even if it was not successfully delivered.
         :param maxlen: count specifies that if there are already count
@@ -201,7 +201,7 @@ class Client(object):
             command += ['REPLICATE', replicate]
         if delay:
             command += ['DELAY', delay]
-        if retry:
+        if retry is not None:
             command += ['RETRY', retry]
         if ttl:
             command += ['TTL', ttl]


### PR DESCRIPTION
It doesn't send RETRY argument to server if I set retry=0. The bad news is that '1' will requeue after 5 minutes again.

``` python
c.add_job('q', 1, retry=0)
```

And retry=0 means "at most once".

Reference here: 
[http://antirez.com/news/88](url)
