### PR TITLE
raise "ConnectionError" instead of "Exception" on connection error

### DIFF
--- a/pydisque/client.py
+++ b/pydisque/client.py
@@ -128,7 +128,7 @@ class Client(object):
             except redis.exceptions.ConnectionError:
                 pass
         if not self.connected_node:
-            raise Exception('couldnt connect to any nodes')
+            raise ConnectionError('couldnt connect to any nodes')
         logger.info("connected to node %s" % self.connected_node)
 
     def get_connection(self):
@@ -137,7 +137,10 @@ class Client(object):
 
         :rtype: redis.Redis
         """
-        return self.connected_node.connection
+        if self.connected_node:
+            return self.connected_node.connection
+        else:
+            raise ConnectionError("not connected")
 
     @retry()
     def execute_command(self, *args, **kwargs):


### PR DESCRIPTION
I've had quite some hassle trying to catch exceptions in a work queue I've built around pydisque (https://github.com/kaspar030/dwq), as pydisque just raises Exception().

It basically makes it impossible to catch e.g., KeyboardInterrupt, or catch signals in order to gracefully exit.

This PR makes pydisque raise ConnectionError if there's a problem using/reconnecting the underlying redis instance.

I piggybacked a fix for get_connection(), which previously would fail with type error if there was no connection.